### PR TITLE
Remove ServiceRouter for candidate service

### DIFF
--- a/deploy/kubernetes/charts/consul-release-controller/templates/controller.yaml
+++ b/deploy/kubernetes/charts/consul-release-controller/templates/controller.yaml
@@ -107,7 +107,7 @@ spec:
       volumes:
         - name: tls-secret
           secret:
-            secretName: {{include "consul-release-controller.fullname" .}}-certificate
+            secretName: consul-release-controller-certificate
         {{- if .Values.controller.additional_volumes }}
         {{- toYaml .Values.controller.additional_volumes | nindent 8 }}
         {{- end }}

--- a/functional_tests/features/kubernetes.feature
+++ b/functional_tests/features/kubernetes.feature
@@ -20,7 +20,6 @@ Feature: Kubernetes
       And a Kubernetes deployment called "api-deployment" should not exist
       And a Consul "service-defaults" called "api" should be created
       And a Consul "service-resolver" called "api" should be created
-      And a Consul "service-router" called "api" should be created
       And a Consul "service-splitter" called "api" should be created
       And eventually a call to the URL "https://localhost:9443/v1/releases" contains the text
         """
@@ -58,7 +57,6 @@ Feature: Kubernetes
         """
       And a Consul "service-defaults" called "api" should be created
       And a Consul "service-resolver" called "api" should be created
-      And a Consul "service-router" called "api" should be created
     When I create a new version of the Kubernetes deployment "./config/api.yaml"
       Then a Kubernetes deployment called "api-deployment-primary" should exist
       And a Kubernetes deployment called "api-deployment" should not exist
@@ -101,7 +99,6 @@ Feature: Kubernetes
       And a Kubernetes deployment called "api-deployment" should not exist
       And a Consul "service-defaults" called "api" should be created
       And a Consul "service-resolver" called "api" should be created
-      And a Consul "service-router" called "api" should be created
       And eventually a call to the URL "https://localhost:9443/v1/releases" contains the text
         """
         "status":"state_idle"
@@ -135,7 +132,7 @@ Feature: Kubernetes
     When I create a new Kubernetes release "./config/api_release_with_check.yaml"
       Then a Consul "service-defaults" called "api" should be created
       And a Consul "service-resolver" called "api" should be created
-      And a Consul "service-router" called "api" should be created
+      And a Consul "service-router" called "consul-release-controller-upstreams" should be created
       And eventually a call to the URL "https://localhost:9443/v1/releases" contains the text
         """
         "status":"state_idle"
@@ -186,7 +183,7 @@ Feature: Kubernetes
       And a Kubernetes deployment called "api-deployment" should not exist
       And a Consul "service-defaults" called "api" should be created
       And a Consul "service-resolver" called "api" should be created
-      And a Consul "service-router" called "api" should be created
+      And a Consul "service-router" called "consul-release-controller-upstreams" should be created
       And eventually a call to the URL "https://localhost:9443/v1/releases" contains the text
         """
         "status":"state_idle"

--- a/plugins/consul/plugin.go
+++ b/plugins/consul/plugin.go
@@ -120,17 +120,6 @@ func (p *Plugin) Setup(ctx context.Context) error {
 
 	time.Sleep(syncDelay)
 
-	// create the service router
-	p.log.Debug("Create service router", "service", p.config.ConsulService)
-	err = p.consulClient.CreateServiceRouter(p.config.ConsulService)
-	if err != nil {
-		p.log.Error("Unable to create Consul ServiceRouter", "name", p.config.ConsulService, "error", err)
-
-		return err
-	}
-
-	time.Sleep(syncDelay)
-
 	// create the service router to enable post deployment tests
 	p.log.Debug("Create upstream service router", "service", p.config.ConsulService)
 	err = p.consulClient.CreateUpstreamRouter(p.config.ConsulService)
@@ -178,16 +167,6 @@ func (p *Plugin) Destroy(ctx context.Context) error {
 	err := p.consulClient.DeleteServiceSplitter(p.config.ConsulService)
 	if err != nil {
 		p.log.Error("Unable to delete Consul ServiceSplitter", "name", p.config.ConsulService, "error", err)
-
-		return err
-	}
-
-	time.Sleep(syncDelay)
-
-	p.log.Debug("Cleanup router", "name", p.config.ConsulService)
-	err = p.consulClient.DeleteServiceRouter(p.config.ConsulService)
-	if err != nil {
-		p.log.Error("Unable to delete Consul ServiceRouter", "name", p.config.ConsulService, "error", err)
 
 		return err
 	}

--- a/plugins/consul/plugin_test.go
+++ b/plugins/consul/plugin_test.go
@@ -24,7 +24,6 @@ func setupPlugin(t *testing.T) (*Plugin, *clients.ConsulMock) {
 
 	mc.On("CreateServiceDefaults", mock.Anything).Return(nil)
 	mc.On("CreateServiceResolver", mock.Anything).Return(nil)
-	mc.On("CreateServiceRouter", mock.Anything, mock.Anything).Return(nil)
 	mc.On("CreateUpstreamRouter", mock.Anything, mock.Anything).Return(nil)
 	mc.On("CreateServiceSplitter", mock.Anything, mock.Anything, mock.Anything).Return(nil)
 	mc.On("CreateServiceIntention", mock.Anything, mock.Anything).Return(nil)
@@ -32,7 +31,6 @@ func setupPlugin(t *testing.T) (*Plugin, *clients.ConsulMock) {
 	mc.On("DeleteServiceSplitter", mock.Anything).Return(nil)
 	mc.On("DeleteServiceDefaults", mock.Anything).Return(nil)
 	mc.On("DeleteServiceResolver", mock.Anything).Return(nil)
-	mc.On("DeleteServiceRouter", mock.Anything).Return(nil)
 	mc.On("DeleteUpstreamRouter", mock.Anything).Return(nil)
 	mc.On("DeleteServiceIntention", mock.Anything).Return(nil)
 
@@ -146,25 +144,6 @@ func TestSetupFailsOnCreateServiceResolverError(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestSetupCreatesConsulServiceRouter(t *testing.T) {
-	p, mc := setupPlugin(t)
-
-	err := p.Setup(context.Background())
-	require.NoError(t, err)
-
-	mc.AssertCalled(t, "CreateServiceRouter", "api")
-}
-
-func TestSetupFailsOnCreateServiceRouterError(t *testing.T) {
-	p, mc := setupPlugin(t)
-
-	testutils.ClearMockCall(&mc.Mock, "CreateServiceRouter")
-	mc.On("CreateServiceRouter", mock.Anything).Return(fmt.Errorf("boom"))
-
-	err := p.Setup(context.Background())
-	require.Error(t, err)
-}
-
 func TestSetupCreatesUpstreamServiceRouter(t *testing.T) {
 	p, mc := setupPlugin(t)
 
@@ -236,25 +215,6 @@ func TestDestroyFailsOnDeletesServiceSplitterError(t *testing.T) {
 
 	testutils.ClearMockCall(&mc.Mock, "DeleteServiceSplitter")
 	mc.On("DeleteServiceSplitter", mock.Anything).Return(fmt.Errorf("boom"))
-
-	err := p.Destroy(context.Background())
-	require.Error(t, err)
-}
-
-func TestDestroyDeletesServiceRouter(t *testing.T) {
-	p, mc := setupPlugin(t)
-
-	err := p.Destroy(context.Background())
-	require.NoError(t, err)
-
-	mc.AssertCalled(t, "DeleteServiceRouter", "api")
-}
-
-func TestDestroyFailsOnDeleteServiceRouterError(t *testing.T) {
-	p, mc := setupPlugin(t)
-
-	testutils.ClearMockCall(&mc.Mock, "DeleteServiceRouter")
-	mc.On("DeleteServiceRouter", mock.Anything).Return(fmt.Errorf("boom"))
 
 	err := p.Destroy(context.Background())
 	require.Error(t, err)


### PR DESCRIPTION
Automatically creating a service router for the candidate service stops the end-user from defining their own routers