### PR TITLE
Enable TLS for API can be disabled

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -58,11 +58,11 @@ jobs:
       matrix:
         tags:
           - "@k8s_canary_existing"
-            #- "@k8s_canary_none"
-            #- "@k8s_canary_rollback"
-            #- "@k8s_canary_with_post_deployment_test"
-            #- "@k8s_canary_with_post_deployment_test_fail"
-          - "@nomad_canary_existing"
+           - "@k8s_canary_none"
+           - "@k8s_canary_rollback"
+           - "@k8s_canary_with_post_deployment_test"
+           - "@k8s_canary_with_post_deployment_test_fail"
+            #- "@nomad_canary_existing"
     steps:
     - uses: actions/checkout@v2
 

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -58,10 +58,10 @@ jobs:
       matrix:
         tags:
           - "@k8s_canary_existing"
-           - "@k8s_canary_none"
-           - "@k8s_canary_rollback"
-           - "@k8s_canary_with_post_deployment_test"
-           - "@k8s_canary_with_post_deployment_test_fail"
+          - "@k8s_canary_none"
+          - "@k8s_canary_rollback"
+          - "@k8s_canary_with_post_deployment_test"
+          - "@k8s_canary_with_post_deployment_test_fail"
             #- "@nomad_canary_existing"
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -62,7 +62,7 @@ jobs:
             #- "@k8s_canary_rollback"
             #- "@k8s_canary_with_post_deployment_test"
             #- "@k8s_canary_with_post_deployment_test_fail"
-            # - "@nomad_canary_existing"
+          - "@nomad_canary_existing"
     steps:
     - uses: actions/checkout@v2
 


### PR DESCRIPTION
This PR makes a small change that enables the TLS endpoint for the API to be disabled. While TLS is encouraged for production use this change can make testing and evaluation easier.